### PR TITLE
Fixed regex validation for puppet 4 and 5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,9 +92,9 @@ class syslogng (
     'kernel'   => {},
   },
   $chain_hostnames = false,
-  $flush_lines     = 0,
-  $log_fifo_size   = 1000,
-  $stats_freq      = 43200
+  $flush_lines     = '0',
+  $log_fifo_size   = '1000',
+  $stats_freq      = '43200'
 ) {
   validate_re($ensure, [ '^present', '^absent' ])
   validate_absolute_path($conf_dir)


### PR DESCRIPTION
Some parameters needs to be as a string, becuase puppet is raising
error: "Error while evaluating a Function Call, validate_re():
input needs to be a String, not a Fixnum"

Related to: https://github.com/purplehazech/puppet-syslogng/issues/10